### PR TITLE
Updated Db.cs, getting error on AsMultiResultSet

### DIFF
--- a/Net.Code.ADONet/Net.Code.ADONet/Db.cs
+++ b/Net.Code.ADONet/Net.Code.ADONet/Db.cs
@@ -338,7 +338,7 @@ namespace Net.Code.ADONet
             } while (reader.NextResult());
         }
 
-        private static IEnumerable<dynamic> GetResultSet(IDataReader reader)
+        public static IEnumerable<dynamic> GetResultSet(IDataReader reader)
         {
             while (reader.Read()) yield return reader.ToExpando();
         }
@@ -384,7 +384,12 @@ namespace Net.Code.ADONet
         {
             using (var reader = Execute().Reader())
             {
-                return reader.ToMultiResultSet();
+                //return reader.ToMultiResultSet();
+
+                do
+                {
+                    yield return DataReaderExtensions.GetResultSet(reader);
+                } while (reader.NextResult());
             }
         }
 


### PR DESCRIPTION
Getting datareader is closed error when using default implementation of AsMultiResultSet.  Had to call into the GetResultSet instead of using the extension ToMultiResultSet method. (.NET 4.5)